### PR TITLE
Use latest version of alpine instead of edge (development)

### DIFF
--- a/alpine/Dockerfile.alpine
+++ b/alpine/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:latest
 
 ADD kamailio_min-without_os_files.tar.gz /
 

--- a/alpine/Dockerfile.debug
+++ b/alpine/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:latest
 
 RUN apk --no-cache add gawk ca-certificates gdb strace mariadb-client postgresql-client musl-dbg; \
     apk --no-cache --allow-untrusted --repository http://local-repo search search -qe 'kamailio*' | \

--- a/alpine/hooks/pre_build
+++ b/alpine/hooks/pre_build
@@ -6,6 +6,6 @@ if [ ! -z "$SOURCE_BRANCH" ];then
     ENV_OPT="-e SOURCE_BRANCH=$SOURCE_BRANCH"
 fi
 
-docker run --volume=`pwd`/../../..:/usr/src/kamailio --volume=`pwd`/build.sh:/build.sh --entrypoint=/build.sh $ENV_OPT alpine:edge
+docker run --volume=`pwd`/../../..:/usr/src/kamailio --volume=`pwd`/build.sh:/build.sh --entrypoint=/build.sh $ENV_OPT alpine:latest
 
 exit $?


### PR DESCRIPTION
As `alpine:edge` is the development branch of `alpine`, it would be safer to build docker images from a stable release.

Docker image `alpine:edge` is currently breaking when trying to install packages from npm (or yarn).
See following issues:
  - https://github.com/yarnpkg/yarn/issues/6396
  - https://github.com/yarnpkg/yarn/issues/6384
